### PR TITLE
Fixed #23; Retarget to vscode 1.6; better command logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.4.3",
   "publisher": "mrcrowl",
   "engines": {
-    "vscode": "^1.5.0"
+    "vscode": "^1.6.0"
   },
   "categories": [
     "Other"
@@ -108,6 +108,6 @@
   },
   "devDependencies": {
     "typescript": "2.1.4",
-    "vscode": "^1.0.0"
+    "vscode": "^1.1.0"
   }
 }

--- a/src/CompileLessCommand.ts
+++ b/src/CompileLessCommand.ts
@@ -27,7 +27,7 @@ class CompileLessCommand
         const startTime: number = Date.now();
         try
         {
-            await LessCompiler.compile(this.document.fileName, globalOptions);
+            await LessCompiler.compile(this.document.fileName, this.document.getText(), globalOptions);
             const elapsedTime: number = (Date.now() - startTime);
             compilingMessage.dispose();
             this.lessDiagnosticCollection.set(this.document.uri, []);

--- a/src/LessCompiler.ts
+++ b/src/LessCompiler.ts
@@ -12,10 +12,8 @@ import FileOptionsParser = require("./FileOptionsParser");
 const DEFAULT_EXT = ".css";
 
 // compile the given less file
-export async function compile(lessFile: string, defaults: Configuration.EasyLessOptions): Promise<void>
+export async function compile(lessFile: string, content: string, defaults: Configuration.EasyLessOptions): Promise<void>
 {
-    const buffer = await readFilePromise(lessFile);
-    const content: string = buffer.toString();
     const options: Configuration.EasyLessOptions = FileOptionsParser.parse(content, defaults);
     const lessPath: string = path.dirname(lessFile);
 
@@ -30,7 +28,8 @@ export async function compile(lessFile: string, defaults: Configuration.EasyLess
                 const mainPath: path.ParsedPath = path.parse(filePath);
                 const mainRootFileInfo = Configuration.getRootFileInfo(mainPath);
                 const mainDefaults = extend({}, defaults, { rootFileInfo: mainRootFileInfo });
-                await compile(filePath, mainDefaults);
+                const mainContent = await readFilePromise(lessFile, "utf-8");
+                await compile(filePath, mainContent, mainDefaults);
             }
             return;
         }
@@ -176,11 +175,11 @@ function writeFileContents(this: void, filepath: string, content: any): Promise<
     });
 }
 
-function readFilePromise(this: void, filename: string): Promise<Buffer> 
+function readFilePromise(this: void, filename: string, encoding: string): Promise<string> 
 {
     return new Promise((resolve, reject) =>
     {
-        fs.readFile(filename, (err: any, buffer: Buffer) =>
+        fs.readFile(filename, encoding, (err: any, data: string) =>
         {
             if (err) 
             {
@@ -188,7 +187,7 @@ function readFilePromise(this: void, filename: string): Promise<Buffer>
             }
             else
             {
-                resolve(buffer);
+                resolve(data);
             }
         });
     });

--- a/src/LessCompiler.ts
+++ b/src/LessCompiler.ts
@@ -28,7 +28,7 @@ export async function compile(lessFile: string, content: string, defaults: Confi
                 const mainPath: path.ParsedPath = path.parse(filePath);
                 const mainRootFileInfo = Configuration.getRootFileInfo(mainPath);
                 const mainDefaults = extend({}, defaults, { rootFileInfo: mainRootFileInfo });
-                const mainContent = await readFilePromise(lessFile, "utf-8");
+                const mainContent = await readFilePromise(filePath, "utf-8");
                 await compile(filePath, mainContent, mainDefaults);
             }
             return;

--- a/src/LessCompiler.ts
+++ b/src/LessCompiler.ts
@@ -92,25 +92,8 @@ export async function compile(lessFile: string, defaults: Configuration.EasyLess
 
         if (!sourceMapOptions.sourceMapFileInline)
         {
-            // currently just has support for writing .map file to same directory
-            const lessPath: string = path.parse(lessFile).dir;
-            const cssPath: string = path.parse(cssFile).dir;
-            const lessRelativeToCss: string = path.relative(cssPath, lessPath);
-
-            const sourceMapOptions = <Less.SourceMapOption>{
-                outputSourceFiles: false,
-                sourceMapBasepath: lessPath,
-                sourceMapFileInline: options.sourceMapFileInline,
-                sourceMapRootpath: lessRelativeToCss,
-            };
-
-            if (!sourceMapOptions.sourceMapFileInline)
-            {
-                sourceMapFile = cssFile + '.map';
-                sourceMapOptions.sourceMapURL = "./" + baseFilename + extension + ".map";
-            }
-
-            options.sourceMap = sourceMapOptions;
+            sourceMapFile = cssFile + '.map';
+            sourceMapOptions.sourceMapURL = "./" + baseFilename + extension + ".map";
         }
 
         options.sourceMap = sourceMapOptions;

--- a/src/LessCompiler.ts
+++ b/src/LessCompiler.ts
@@ -8,6 +8,7 @@ import { EasyLessOptions } from "./Configuration";
 
 import Configuration = require("./Configuration");
 import FileOptionsParser = require("./FileOptionsParser");
+import { LessDocumentResolverPlugin } from "./LessDocumentResolverPlugin";
 
 const DEFAULT_EXT = ".css";
 
@@ -108,6 +109,8 @@ export async function compile(lessFile: string, content: string, defaults: Confi
 
         options.plugins.push(autoprefixPlugin);
     }
+
+    options.plugins.push(new LessDocumentResolverPlugin());
 
     // set up the parser
     const output = await less.render(content, options);

--- a/src/LessDocumentResolverPlugin.ts
+++ b/src/LessDocumentResolverPlugin.ts
@@ -1,0 +1,24 @@
+import * as path from "path";
+
+import * as vscode from 'vscode';
+import * as less from "less";
+
+export class LessDocumentResolverPlugin implements Less.Plugin
+{
+    install(less: LessStatic, pluginManager: Less.PluginManager)
+    {
+        pluginManager.addPreProcessor(new LessDocumentResolver());
+    }
+}
+
+class LessDocumentResolver implements Less.PreProcessor
+{
+    process(src: string, extra: Less.PreProcessorExtraInfo)
+    {
+        const file = path.normalize(path.resolve(extra.fileInfo.entryPath, extra.fileInfo.filename));
+        const document = vscode.workspace.textDocuments.find(document => document.fileName == file);
+        if (document !== undefined)
+            return document.getText();
+        return src;
+    }
+}

--- a/src/easyLess.ts
+++ b/src/easyLess.ts
@@ -42,11 +42,11 @@ export function activate(context: vscode.ExtensionContext)
     });
 
     // automatically compile less on save
-    const didSaveEvent = vscode.workspace.onDidSaveTextDocument((doc: vscode.TextDocument) =>
+    const willSaveEvent = vscode.workspace.onWillSaveTextDocument(e =>
     {
-        if (doc.fileName.endsWith(LESS_EXT))
+        if (e.document.fileName.endsWith(LESS_EXT))
         {
-            vscode.commands.executeCommand(COMPILE_COMMAND, doc);
+            vscode.commands.executeCommand(COMPILE_COMMAND, e.document);
         }
     });
 
@@ -60,7 +60,7 @@ export function activate(context: vscode.ExtensionContext)
     })
 
     context.subscriptions.push(compileLessSub);
-    context.subscriptions.push(didSaveEvent);
+    context.subscriptions.push(willSaveEvent);
     context.subscriptions.push(didCloseEvent);
 }
 

--- a/src/easyLess.ts
+++ b/src/easyLess.ts
@@ -13,31 +13,25 @@ export function activate(context: vscode.ExtensionContext)
     lessDiagnosticCollection = vscode.languages.createDiagnosticCollection();
 
     // compile less command
-    const compileLessSub = vscode.commands.registerCommand(COMPILE_COMMAND, (document?: vscode.TextDocument) =>
+    const compileLessSub = vscode.commands.registerCommand(COMPILE_COMMAND, () =>
     {
-        // if no document argument given, use the active text editor
-        if (!document)
+        const activeEditor: vscode.TextEditor = vscode.window.activeTextEditor;
+        if (activeEditor)
         {
-            const activeEditor: vscode.TextEditor = vscode.window.activeTextEditor;
-            if (activeEditor)
+            const document = activeEditor.document;
+
+            if (document.fileName.endsWith(LESS_EXT))
             {
-                document = activeEditor.document;
+                document.save();
             }
             else
             {
-                vscode.window.showInformationMessage("This command is only available when a .less editor is open.");
-                return;
+                vscode.window.showWarningMessage("This command only works for .less files.");
             }
-        }
-
-        if (document.fileName.endsWith(LESS_EXT))
-        {
-            const organise = new CompileLessCommand(document, lessDiagnosticCollection);
-            organise.execute();
         }
         else
         {
-            vscode.window.showWarningMessage("This command only works for .less files.");
+            vscode.window.showInformationMessage("This command is only available when a .less editor is open.");
         }
     });
 
@@ -46,7 +40,8 @@ export function activate(context: vscode.ExtensionContext)
     {
         if (e.document.fileName.endsWith(LESS_EXT))
         {
-            vscode.commands.executeCommand(COMPILE_COMMAND, e.document);
+            const organise = new CompileLessCommand(e.document, lessDiagnosticCollection);
+            organise.execute();
         }
     });
 


### PR DESCRIPTION
This pr contains 3 changes:

1. Fixed #23. This [commit](https://github.com/mrcrowl/vscode-easy-less/commit/2dad788984ebb7d9ea3298fe128415e0c3df8b30#diff-f956c03ce70ae3bbc0ff574ce1280759R95) causes `options.sourceMap` to be overwritten, why do you do this? Incorrectly resolved merge conflict?

2. Retarget to vscode 1.6, so I can use the new [`onWillSaveTextDocument`](https://github.com/mrcrowl/vscode-easy-less/compare/master...CnSimonChan:master#diff-6b9621c92b37297a75f0cc10363bc687R39) instead of `onDidSaveTextDocument`. 

    `onWillSaveTextDocument` event will be triggered when auto-save or explicitly invoke save command, even if the file is not dirty, i.e when imports changed, user can hit `Ctrl` + `S`/`Command` + `S` to trigger a re-compilation easily.

    Because of the file on disk is not updated when `onWillSaveTextDocument` fires, so I also changed to use `Document#getText()` to get the content, except for reading the main file.

3. Changed the logic of the command. The command will just save the `.less` file. I  think when invoke the command on a dirty file, it's more reasonable to save the file first. Then the event handler will do the remaining thing.

I'm new to vscode extension development, so if there is anything wrong, please correct me!