### PR TITLE
FIX wrong type "data" argument

### DIFF
--- a/src/LessCompiler.ts
+++ b/src/LessCompiler.ts
@@ -172,7 +172,7 @@ function writeFileContents(this: void, filepath: string, content: any): Promise<
         return reject(err);
       }
 
-      fs.writeFile(filepath, content, (err) => {
+      fs.writeFile(filepath, content.toString(), (err) => {
         if (err) {
           reject(err);
         } else {


### PR DESCRIPTION
FIX:
The file is compiling and stuck in state "compiling less" (the file is generated, but no information about error or the end of process)
(this fix is maybe not the cleaner manner to avoid that)

Showing this message in log:
[renderer1] [error] The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of SourceMapGenerator: TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of SourceMapGenerator
    at Object.writeFile (fs.js:1436:5)
    at /***/.vscode/extensions/mrcrowl.easy-less-1.7.2/out/LessCompiler.js:166:16
    at /***/.vscode/extensions/mrcrowl.easy-less-1.7.2/node_modules/mkpath/mkpath.js:36:13
    at FSReqCallback.oncomplete (fs.js:184:5)