### PR TITLE
added: sub-folders manager on compilation

### DIFF
--- a/src/LessCompiler.ts
+++ b/src/LessCompiler.ts
@@ -99,6 +99,13 @@ function chooseOutputFilename(options: Configuration.EasyLessOptions, lessFile: 
 
     cssRelativeFilename = interpolatedOut;
 
+    /**
+     * Get the sub-folders of the '/less/' folder to then add these sub-folders
+     * to the css 'out' folder specified in 'settings.json'
+     */
+    const subFolders = getSubfolders(lessPath);
+    cssRelativeFilename = `${cssRelativeFilename}${subFolders}`;
+
     if (isFolder(cssRelativeFilename)) {
       // Folder.
       cssRelativeFilename = `${cssRelativeFilename}${filenameNoExtension}${extension}`;
@@ -107,7 +114,9 @@ function chooseOutputFilename(options: Configuration.EasyLessOptions, lessFile: 
       cssRelativeFilename = `${cssRelativeFilename}${extension}`;
     }
   } else {
-    // `out` not set: output to the same basename as the less file
+    // `out` not set: output to '/css/' inside the same basename as the less file
+    lessPath = `${lessPath}/css/`;
+
     cssRelativeFilename = filenameNoExtension + extension;
   }
 
@@ -214,4 +223,22 @@ function ensureDotPrefixed(extension: string): string {
   }
 
   return extension ? `.${extension}` : ''; // ###
+}
+
+function getSubfolders(path: string): string {
+  const parts = path.split('/');
+  const lessIndex = parts.indexOf('less');
+
+  if (lessIndex === -1 || lessIndex === parts.length - 1) {
+    // If "less" folder doesn't exist or is the last part, return empty string
+    return '';
+  }
+
+  // Get subfolders after "less"
+  const subfolders = parts.slice(lessIndex + 1);
+
+  // Join subfolders with '/' and add '/' to the last subfolder
+  const concatenatedSubfolders = subfolders.join('/') + '/';
+
+  return concatenatedSubfolders;
 }


### PR DESCRIPTION
Inside LessCompiler.ts:

Added a function, getSubFolders, to get the sub folders of a specified path. This is used inside the function chooseOutputFilename, so if inside the settings.json is specified a folder path as a different output, the .css files will not be created all right away, but following the folder structure the .less files are in.

This change, though, only works if the "root" of the less files is called "less". Hence for example, given the next structure:

+ style
+-- less
+---- components
+------ input.less
+------ button.less
+---- pages
+------ home.less


If we save for example the home.less file, and hypothesizing that settings.json => "out": "style/css/",  instead of creating the home.css inside "style/css/home.css", it is created as follows: "style/css/pages/home.css".

This upgrade would simplify our life since we would no more need to write the first comment in each .less file (as i had to do previously, as long this was already possible but i didn't find the solution).

Another add:
If the "out" is not set inside settings.json, the css files are compiled in their specific "css" folder inside the same basename as the less file
